### PR TITLE
Fixed clang-tidy issues

### DIFF
--- a/src/command/command_ast.c
+++ b/src/command/command_ast.c
@@ -443,6 +443,9 @@ add_result (command_ast_output_t * p_result, char * p_token)
     p_result->argc++;
     p_result->argv = realloc(p_result->argv, p_result->argc * sizeof(char *));
 
+    // Initialize the value.
+    p_result->argv[p_result->argc - 1] = NULL;
+
     // Allocate the string.
     size_t tok_len = strlen(p_token);
     char * p_str = calloc(tok_len + 1, sizeof(char));
@@ -450,7 +453,7 @@ add_result (command_ast_output_t * p_result, char * p_token)
     {
         goto EXIT;
     }
-    strcpy(p_str, p_token);
+    stpncpy(p_str, p_token, tok_len);
 
     // Add string to argv.
     p_result->argv[p_result->argc - 1] = p_str;

--- a/src/command/command_ast.h
+++ b/src/command/command_ast.h
@@ -9,8 +9,8 @@
  *          structured format.
  */
 
-#ifndef WW_COMMAND_AST_H
-#define WW_COMMAND_AST_H
+#ifndef _WEBWASP_SRC_COMMAND_COMMAND_AST_H
+#define _WEBWASP_SRC_COMMAND_COMMAND_AST_H
 
 #include <stdlib.h>
 
@@ -85,6 +85,6 @@ command_ast_complete (const command_ast_t * p_ast,
 int
 command_ast_clean (command_ast_output_t * p_result);
 
-#endif // WW_COMMAND_AST_H
+#endif // _WEBWASP_SRC_COMMAND_COMMAND_AST_H
 
 /***   end of file   ***/

--- a/src/command/node.c
+++ b/src/command/node.c
@@ -51,7 +51,7 @@ node_create (const char * p_data)
     {
         goto EXIT;
     }
-    strcpy(p_node->p_data, p_data);
+    stpncpy(p_node->p_data, p_data, data_len);
 
     status = 0;
 

--- a/src/command/node.h
+++ b/src/command/node.h
@@ -5,8 +5,8 @@
  *          syntax tree.
  */
 
-#ifndef WW_COMMAND_NODE_H
-#define WW_COMMAND_NODE_H
+#ifndef _WEBWASP_SRC_COMMAND_NODE_H
+#define _WEBWASP_SRC_COMMAND_NODE_H
 
 #include <stdint.h>
 #include <stdlib.h>
@@ -61,6 +61,6 @@ node_destroy (node_t * p_node);
 int
 node_adopt (node_t * p_parent, node_t * p_child);
 
-#endif // WW_COMMAND_NODE_H
+#endif // _WEBWASP_SRC_COMMAND_NODE_H
 
 /***   end of file   ***/

--- a/src/common/string_utils.h
+++ b/src/common/string_utils.h
@@ -4,8 +4,8 @@
  * @brief This file contains various string utility functions.
  */
 
-#ifndef _CODE_WEBWASP_SRC_COMMON_STRING_UTILS_H
-#define _CODE_WEBWASP_SRC_COMMON_STRING_UTILS_H
+#ifndef _WEBWASP_SRC_COMMON_STRING_UTILS_H
+#define _WEBWASP_SRC_COMMON_STRING_UTILS_H
 
 #include <stdlib.h>
 
@@ -49,6 +49,6 @@ string_split (const char * p_str, const char * p_del);
 void
 string_split_destroy (string_split_t * p_split);
 
-#endif // _CODE_WEBWASP_SRC_COMMON_STRING_UTILS_H
+#endif // _WEBWASP_SRC_COMMON_STRING_UTILS_H
 
 /***   end of file   ***/

--- a/src/common/vector.c
+++ b/src/common/vector.c
@@ -77,7 +77,6 @@ vector_destroy (vector_t * p_vector)
             free(p_vector);
             p_vector = NULL;
         }
-        return;
 }
 
 /*!

--- a/src/common/vector.h
+++ b/src/common/vector.h
@@ -22,8 +22,8 @@
  *              - vector_at()
  */
 
-#ifndef WW_COMMON_VECTOR_H
-#define WW_COMMON_VECTOR_H
+#ifndef _WEBWASP_SRC_COMMON_VECTOR_H
+#define _WEBWASP_SRC_COMMON_VECTOR_H
 
 #include <stdlib.h>
 
@@ -130,6 +130,6 @@ vector_pop_front (vector_t * p_vector);
 void *
 vector_at (vector_t * p_vector, const size_t idx);
 
-#endif // WW_COMMON_VECTOR_H
+#endif // _WEBWASP_SRC_COMMON_VECTOR_H
 
 /***   end of file   ***/

--- a/src/console/config.h
+++ b/src/console/config.h
@@ -5,14 +5,14 @@
  *          console to be set at compile time.
  */
 
-#ifndef WW_CONSOLE_CONFIG_H
-#define WW_CONSOLE_CONFIG_H
+#ifndef _WEBWASP_SRC_CONSOLE_CONFIG_H
+#define _WEBWASP_SRC_CONSOLE_CONFIG_H
 
 /***   History config   ***/
 
 // The number of previous commands the history saves.
 #define HISTORY_DEFAULT_LEN 20
 
-#endif // WW_CONSOLE_CONFIG_H
+#endif // _WEBWASP_SRC_CONSOLE_CONFIG_H
 
 /***   end of file   ***/

--- a/src/console/console.h
+++ b/src/console/console.h
@@ -1,13 +1,13 @@
 /*!
- * @file console.h
+ * @file src/console/console.h
  *
  * @brief This file contains the implementation for the console. It
  *          is responsible for gathering user input and passing
  *          commands of to respective modules.
  */
 
-#ifndef WW_CONSOLE_CONSOLE_H
-#define WW_CONSOLE_CONSOLE_H
+#ifndef _WEBWASP_SRC_CONSOLE_CONSOLE_H
+#define _WEBWASP_SRC_CONSOLE_CONSOLE_H
 
 #include <stdlib.h>
 #include <termios.h>
@@ -65,6 +65,6 @@ console_destroy (console_t * p_console);
 void
 console_run (console_t * p_console);
 
-#endif // WW_CONSOLE_CONSOLE_H
+#endif // _WEBWASP_SRC_CONSOLE_CONSOLE_H
 
 /***   end of file   ***/

--- a/src/console/history.c
+++ b/src/console/history.c
@@ -1,5 +1,5 @@
 /*!
- * @file history.c
+ * @file src/console/history.c
  *
  * @brief This file contains an implementation for handling the console's
  *          command history.
@@ -109,7 +109,7 @@ history_push (history_t * p_history, const char * p_cmd)
     // Heap allocate a copy of the new command.
     size_t cmd_len = strlen(p_cmd);
     char * p_new = calloc(cmd_len + 1, sizeof(char));
-    strncpy(p_new, p_cmd, cmd_len);
+    stpncpy(p_new, p_cmd, cmd_len);
 
     // If the array is full, free the last command in the array.
     if (p_history->size == p_history->cap)

--- a/src/console/history.h
+++ b/src/console/history.h
@@ -1,12 +1,12 @@
 /*!
- * @file history.h
+ * @file src/console/history.h
  *
  * @brief This file contains an implementation for handling the console's
  *          command history.
  */
 
-#ifndef WW_CONSOLE_HISTORY_H
-#define WW_CONSOLE_HISTORY_H
+#ifndef _WEBWASP_SRC_CONSOLE_HISTORY_H
+#define _WEBWASP_SRC_CONSOLE_HISTORY_H
 
 #include <stdlib.h>
 #include <string.h>
@@ -60,6 +60,6 @@ history_destroy (history_t * p_history);
 int
 history_push (history_t * p_history, const char * p_cmd);
 
-#endif // WW_CONSOLE_HISTORY_H
+#endif // _WEBWASP_SRC_CONSOLE_HISTORY_H
 
 /***   end of file   ***/


### PR DESCRIPTION
Fixed most issues associated with ```clang-tidy```.

Issues still persist in ```console.c```, but are minimal, mostly dealing with termios config and magic numbers that shouldn't be defined, since it sacrifices readability.

Can be resolved with more oversight in a future PR.