### PR TITLE
Var command refactor

### DIFF
--- a/src/command/command_interface.py
+++ b/src/command/command_interface.py
@@ -27,7 +27,7 @@ class CommandInterface(ABC):
             "--help",
             action="help",
             default=argparse.SUPPRESS,
-            help="show this help message"
+            help="Show this help message"
         )
 
     @abstractmethod

--- a/src/command/command_var.py
+++ b/src/command/command_var.py
@@ -29,33 +29,56 @@ class CommandVar(CommandInterface):
         )
         super().add_help(self.parser)
 
-        # Add argparse args.
-        self.parser.add_argument(
+        # Create the subparser object.
+        self.subparser = self.parser.add_subparsers()
+
+        # Create the var add command subparser.
+        self.parser_add = self.subparser.add_parser(
+            'add',
+            description='Add a variable',
+            help='Add a variable',
+            add_help=False,
+        )
+        self.parser_add.set_defaults(func=self._add)
+        super().add_help(self.parser_add)
+        self.parser_add.add_argument(
             'name',
             type=str,
-            help='The name of the new variable'
+            help='The name of the new variable',
         )
-        self.parser.add_argument(
+        self.parser_add.add_argument(
             'value',
             type=str,
-            help='The value of the new variable'
+            help='The value of the new variable',
         )
-        self.parser.add_argument(
-            '-e',
-            action='store_true',
-            help='Export the variable so it is saved between sessions',
+
+        # Create the var remove command subparser.
+        self.parser_remove = self.subparser.add_parser(
+            'remove',
+            description='Remove a variable',
+            help='Remove a variable',
+            add_help=False,
         )
+        self.parser_remove.set_defaults(func=self._remove)
+        super().add_help(self.parser_remove)
+        self.parser_remove.add_argument(
+            'name',
+            type=str,
+            help='The name of the variable to remove',
+        )
+
+        # Create the var clear command subparser.
+        self.parser_clear = self.subparser.add_parser(
+            'clear',
+            description='Remove all variables',
+            help='Remove all variables',
+            add_help=False,
+        )
+        self.parser_clear.set_defaults(func=self._clear)
+        super().add_help(self.parser_clear)
 
     def run(self, parse, console):
         super().run(parse)
-
-        # If no arguments, list out all variables.
-        parse_len = len(parse)
-        if parse_len == 1:
-            for name, val in console.vars.items():
-                print(f"${name} -> '{val}'")
-            return True
-
         # Slice the command name off the parse so we only
         # parse the arguments.
         parse_trunc = parse[1:]
@@ -63,34 +86,20 @@ class CommandVar(CommandInterface):
         try:
             args = self.parser.parse_args(parse_trunc)
         except argparse.ArgumentError:
-            self.get_help()
+            self.parser.print_help()
             return True
         except SystemExit:
             # Don't let argparse exit the program.
             return True
 
-        # Extract arguments.
-        name = args.name
-        val = args.value
-        export_flag = args.e
-
-        # Variable names are not allowed to include the ":" character,
-        # since it is used in formatting of export files.
-        if ":" in name:
-            print("[🛑] Error: var names cannot contain the ':' character")
+        # If no subcommand was specified, show list.
+        if not hasattr(args, "func"):
+            self._list(console)
             return True
 
-        # Add variable entry to console's var property.
-        console.vars[name] = val
-        print(f"${name} -> {val}")
+        args.func(args, console)
 
-        # Export if flag is set.
-        if export_flag:
-            exp_status = self._export_var(name, val, console)
-            if exp_status:
-                print("Exported successfully")
-            else:
-                print("[🛑] Error: Failed to export variable")
+        # TODO: Write console variables to file for persistence.
 
         return True
 
@@ -141,5 +150,43 @@ class CommandVar(CommandInterface):
         except OSError as open_err:
             print(f"{open_err}")
             return False
+
+    def _list(self, console):
+        """
+        This function lists all variables currently stored.
+        """
+        print("Current stored variables:")
+        for name, value in console.vars.items():
+            print(f"   ${name} -> '{value}'")
+
+    def _add(self, args, console):
+        """
+        This function adds a new variable.
+        """
+        if ':' in args.name:
+            print("[🛑] Error: var names cannot contain the ':' character")
+            return
+
+        console.vars[args.name] = args.value
+        print("[🟢] Added variable:")
+        print(f"   ${args.name} -> '{args.value}")
+
+    def _remove(self, args, console):
+        """
+        This function removes a parameter.
+        """
+        if args.name not in console.vars:
+            print(f"[⚠] Variable '{args.name}' does not exist")
+            return
+        del console.vars[args.name]
+        print("[🟢] Removed variable:")
+        print(f"   ${args.name}")
+
+    def _clear(self, args, console):
+        """
+        This function clears the console parameters.
+        """
+        console.vars = {}
+        print("[🟢] All variables cleared")
 
 ###   end of file   ###


### PR DESCRIPTION
This PR refactors the var command to have the following subcommands:

- ```add```: Add a variable
- ```remove```: Remove a variable
- ```clear```: Clear all stored variables