### PR TITLE
Command Matching

### DIFF
--- a/src/command/command_cookies.py
+++ b/src/command/command_cookies.py
@@ -76,6 +76,16 @@ class CommandCookies(CommandInterface):
         # parse the arguments.
         parse_trunc = parse[1:]
 
+        # Match the subcommand.
+        if len(parse_trunc) > 0:
+            matched_subcmd = super()._get_cmd_match(
+                parse_trunc[0],
+                self.subparser.choices.keys(),
+            )
+
+            if matched_subcmd is not None:
+                parse_trunc[0] = matched_subcmd
+
         try:
             args = self.parser.parse_args(parse_trunc)
         except argparse.ArgumentError:

--- a/src/command/command_headers.py
+++ b/src/command/command_headers.py
@@ -83,6 +83,16 @@ class CommandHeaders(CommandInterface):
         # parse the arguments.
         parse_trunc = parse[1:]
 
+        # Match the subcommand.
+        if len(parse_trunc) > 0:
+            matched_subcmd = super()._get_cmd_match(
+                parse_trunc[0],
+                self.subparser.choices.keys(),
+            )
+
+            if matched_subcmd is not None:
+                parse_trunc[0] = matched_subcmd
+
         try:
             args = self.parser.parse_args(parse_trunc)
         except argparse.ArgumentError:

--- a/src/command/command_interface.py
+++ b/src/command/command_interface.py
@@ -8,6 +8,8 @@ interface that all command classes must follow.
 import argparse
 from abc import ABC, abstractmethod
 
+from src.logger import log
+
 class CommandInterface(ABC):
     """
     This class is the command interface for all other command classes.
@@ -42,5 +44,34 @@ class CommandInterface(ABC):
         execution of the command.
         """
         return True
+    
+    def _get_cmd_match(self, cmd, l):
+        """
+        Brief:
+            This function attempts to match the entered command with
+            the closest fit in the subparser.
+
+        Arguments:
+            cmd: str
+                The subcommand entered by the user.
+
+            l: list
+                The list of possible commands.
+        """
+        matches = [c for c in l if c.startswith(cmd)]
+
+        if len(matches) == 1:
+            return matches[0]
+        
+        # If the list comprehension returned multiple values, then the command
+        # was ambiguous.
+        if len(matches) > 1:
+            log(f"Ambiguous command: '{cmd}'. Potential matches:", log_type='error')
+            for match in matches:
+                log(f"   {match}")
+            return None
+        
+        # No matches were returned, so the command was invalid.
+        return None
 
 ###   end of file   ###

--- a/src/command/command_params.py
+++ b/src/command/command_params.py
@@ -76,6 +76,16 @@ class CommandParams(CommandInterface):
         # parse the arguments.
         parse_trunc = parse[1:]
 
+        # Match the subcommand.
+        if len(parse_trunc) > 0:
+            matched_subcmd = super()._get_cmd_match(
+                parse_trunc[0],
+                self.subparser.choices.keys(),
+            )
+
+            if matched_subcmd is not None:
+                parse_trunc[0] = matched_subcmd
+
         try:
             args = self.parser.parse_args(parse_trunc)
         except argparse.ArgumentError:

--- a/src/command/command_response.py
+++ b/src/command/command_response.py
@@ -69,6 +69,16 @@ class CommandResponse(CommandInterface):
         # parse the arguments.
         parse_trunc = parse[1:]
 
+        # Match the subcommand.
+        if len(parse_trunc) > 0:
+            matched_subcmd = super()._get_cmd_match(
+                parse_trunc[0],
+                self.subparser.choices.keys(),
+            )
+
+            if matched_subcmd is not None:
+                parse_trunc[0] = matched_subcmd
+
         try:
             args = self.parser.parse_args(parse_trunc)
         except argparse.ArgumentError:

--- a/src/command/command_var.py
+++ b/src/command/command_var.py
@@ -83,6 +83,15 @@ class CommandVar(CommandInterface):
         # parse the arguments.
         parse_trunc = parse[1:]
 
+        if len(parse_trunc) > 0:
+            matched_subcmd = super()._get_cmd_match(
+                parse_trunc[0],
+                self.subparser.choices.keys(),
+            )
+
+            if matched_subcmd is not None:
+                parse_trunc[0] = matched_subcmd
+
         try:
             args = self.parser.parse_args(parse_trunc)
         except argparse.ArgumentError:

--- a/src/command/command_var.py
+++ b/src/command/command_var.py
@@ -83,6 +83,7 @@ class CommandVar(CommandInterface):
         # parse the arguments.
         parse_trunc = parse[1:]
 
+        # Match the subcommand.
         if len(parse_trunc) > 0:
             matched_subcmd = super()._get_cmd_match(
                 parse_trunc[0],

--- a/src/dispatch.py
+++ b/src/dispatch.py
@@ -76,6 +76,40 @@ command_dict = {
     "cookies"   : command_cookies,
 }
 
+def _get_cmd_match(cmd):
+    """
+    Brief:
+        This function attempts to match the entered command with
+        the closest fit in the command dict.
+
+        For example, if "timeout" is the only command in the dict that
+        starts with the letter "t", then the user should be able to
+        enter "t" and this function will resolve that.
+
+    Arguments:
+        cmd: str
+            The command entered by the user
+
+    Returns:
+        String with the command on success, None on error.
+    """
+    matches = [command for command in command_dict if command.startswith(cmd)]
+
+    # If the list contains a single entry, this is a success.
+    if len(matches) == 1:
+        return matches[0]
+
+    # If the list comprehension returned multiple values, then the command
+    # was ambiguous.
+    if len(matches) > 1:
+        log(f"Ambiguous command: '{cmd}'. Potential matches:", log_type='error')
+        for match in matches:
+            log(f"   {match}")
+        return None
+    
+    # No matches were returned, so the command was invalid.
+    log(f"Error: Unknown command '{cmd}'", log_type='error')
+
 def dispatch(cmd, vars, console):
     """
     This function parses and dispatches a given command.
@@ -113,13 +147,13 @@ def dispatch(cmd, vars, console):
     if parse[0] == "quit" or parse[0] == "exit" or parse[0] == "q":
         return False
 
-    # Check if command exists.
-    if parse[0] not in command_dict:
-        log(f"Error: Unknown command '{parse[0]}'", log_type='error')
+    # Get command best fit.
+    matched_cmd = _get_cmd_match(parse[0])
+    if matched_cmd is None:
         return True
 
     # Run command.
-    command_class = command_dict.get(parse[0])
+    command_class = command_dict.get(matched_cmd)
     return command_class.run(parse, console)
 
 ###   end of file   ###


### PR DESCRIPTION
This PR adds shorthand command resolution to most commands in WebWasp.

This enables the user to specify only as many characters so as to not be ambiguous with their commands.

For example, if "response" is the only command that starts with "r", then the user can enter "r" as the command and it will resolve to "response".

Ambiguous commands, meaning more than one command is possible, will result in an error, and the console will present a list of possible matches the user may have been trying to specify.